### PR TITLE
Change `source` value in config.yaml to fix broken weblink

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ life_cycle: pre-alpha
 license: CC-BY 4.0
 
 # Link to the source repository for this lesson
-source: https://github.com/LiamPattinson/python-packaging
+source: https://github.com/carpentries-incubator/python_packaging/
 
 # Default branch of your lesson
 branch: main


### PR DESCRIPTION
Hello,

Thanks for writing this lesson - I have followed chapter 5 for my own work, and found it very useful (in particular, a clear explanation and recipe for how to use setuptools_scm, which I couldn't find elsewhere).

A v. small PR which I think will fix the broken "Edit on GitHub" link on the website.