### PR TITLE
Add two extra points relating to TestPyPI

### DIFF
--- a/episodes/05-publishing.Rmd
+++ b/episodes/05-publishing.Rmd
@@ -862,7 +862,16 @@ by uploading to TestPyPI:
 $ twine upload --repository testpypi dist/*
 ```
 
-After checking that everything looks right on TestPyPI, we may proceed with installing
+Note that there is a registration process for TestPyPI, and a separate one for PyPI.
+Once uploaded to TestPyPI we can check that everything looks correct using the web interface.
+If you choose to `pip` download from TestPyPI you may need to specify that the dependencies are gotten 
+from PyPI proper by using the `--extra-indec-url` flag. This is because the dependencies may not be available through TestPyPI.
+
+```bash
+$. pip install -i https://test.pypi.org/pypi/ --extra-index-url https://pypi.org/simple epi_models==0.1.0
+```
+
+Once we are happy that all looks correct on TestPyPI we may proceed with installing
 our package to PyPI:
 
 ```bash


### PR DESCRIPTION
Running through this tutorial I was caught out by two things:
- trying to use my PyPI login details to access TestPyPI (its a separate registration)
- trying to pip install from TestPyPI without additionally pointing to PyPI (where the dependencies are most likely to be housed).

I've added notes on these to the relevant section of the tutorial, so that others don't fall into these GOTCHAs.